### PR TITLE
Baseresource dict() calls keys() not _keys()

### DIFF
--- a/heroku3/models/__init__.py
+++ b/heroku3/models/__init__.py
@@ -69,7 +69,7 @@ class BaseResource(object):
 
     def dict(self):
         d = dict()
-        for k in self.keys():
+        for k in self._keys():
             d[k] = self.__dict__.get(k)
 
         return d


### PR DESCRIPTION
Calling dict() on any of the models raises  no attribute 'keys', which
is quite true. They do define a _keys() method though, which does the
right thing.