### PR TITLE
models/configvars - add a dict() method

### DIFF
--- a/heroku3/models/configvars.py
+++ b/heroku3/models/configvars.py
@@ -69,6 +69,8 @@ class ConfigVars(object):
     def to_dict(self):
         return self.data
 
+    dict = to_dict
+    
     @classmethod
     def new_from_dict(cls, d, h=None, **kwargs):
         # Override normal operation because of crazy api.


### PR DESCRIPTION
ConfigVars doesn't inherit BaseResource - no matter.
Add an alias of its to_dict method so that we can call dict() on it like
models that do inherit from BaseResource, which better satisfies duck types