### PR TITLE
add comment field to ssh key

### DIFF
--- a/heroku3/models/key.py
+++ b/heroku3/models/key.py
@@ -4,7 +4,7 @@ from .  import BaseResource
 class Key(BaseResource):
     """Heroku SSH Key."""
 
-    _strs = ['id', 'public_key', 'email', 'fingerprint']
+    _strs = ['id', 'public_key', 'email', 'fingerprint', 'comment']
     _dates = ['created_at', 'updated_at']
     _pks = ['id']
 


### PR DESCRIPTION
as per heroku sample data, ssh keys have a string field for any key comment