### PR TITLE
Arrays of things as members

### DIFF
--- a/heroku3/helpers.py
+++ b/heroku3/helpers.py
@@ -36,6 +36,7 @@ def to_python(obj,
     date_keys=None,
     int_keys=None,
     object_map=None,
+    array_map=None,
     bool_keys=None,
     dict_keys=None,
     **kwargs):
@@ -87,6 +88,11 @@ def to_python(obj,
         for (k, v) in object_map.items():
             if in_dict.get(k):
                 d[k] = v.new_from_dict(in_dict.get(k))
+
+    if array_map:
+        for (k,v) in array_map.items():
+            if in_dict.get(k):
+                d[k] = [ v.new_from_dict(i) for i in in_dict.get(k)]
 
     obj.__dict__.update(d)
     obj.__dict__.update(kwargs)

--- a/heroku3/models/__init__.py
+++ b/heroku3/models/__init__.py
@@ -27,6 +27,7 @@ class BaseResource(object):
     _bools = []
     _dicts = []
     _map = {}
+    _arrays = {}
     _pks = []
     order_by = 'id'
 
@@ -45,7 +46,8 @@ class BaseResource(object):
             setattr(self, attr, None)
 
     def _keys(self):
-        return self._strs + self._ints + self._dates + self._bools + list(self._map.keys())
+        return self._strs + self._ints + self._dates + self._bools + \
+            list(self._map.keys()) + list(self._arrays.keys())
 
     @property
     def _id(self):
@@ -90,6 +92,7 @@ class BaseResource(object):
             bool_keys=cls._bools,
             dict_keys=cls._dicts,
             object_map=cls._map,
+            array_map=cls._arrays,
             _h=h
         )
 


### PR DESCRIPTION
A couple of the Heroku info methods return elements as arrays of
objects ( e.g. builds.buildpacks )

        https://api.heroku.com/apps/example/builds - yields

             {
                  "buildpacks": [
                      {
                          "url": "https://github.com/heroku/heroku-buildpack-ruby"
                      }
                  ],
                  "created_at": "2012-01-01T12:00:00Z",
                  "id": "01234567-89ab-cdef-0123-456789abcdef",
                  "source_blob": {
                      "url": "https://example.com/source.tgz?token=xyz",
                      "version": "v1.3.0"
                  },
                  "slug": {
                      "id": "01234567-89ab-cdef-0123-456789abcdef"
                  },
                  "status": "succeeded",
                  "updated_at": "2012-01-01T12:00:00Z",
                  "user": {
                      "id": "01234567-89ab-cdef-0123-456789abcdef",
                      "email": "username@example.com"
                  }
              }

This patch adds an _arrays bucket to base resource, that works like
object map in as much as it expects a dictionary of keyname : type , and
to_python tries to expand a list comprehension for this keyname to an
array of types.