### PR TITLE
using six.moves to retain py2.7 compatibility

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ venv
 build/
 dist/
 heroku.egg-info/
+*.pyc

--- a/heroku3/api.py
+++ b/heroku3/api.py
@@ -7,25 +7,27 @@ heroku3.api
 This module provides the basic API interface for Heroku.
 """
 
+import sys
+from pprint import pprint  # noqa
+
+import requests
+from requests.exceptions import HTTPError
+
 from .compat import json
 from .helpers import is_collection
 from .models import Plan, RateLimit
-from .models.app import App
-from .models.addon import Addon
-from .models.dyno import Dyno
 from .models.account import Account
-from .models.key import Key
-from .models.invoice import Invoice
+from .models.account.feature import AccountFeature
+from .models.addon import Addon
+from .models.app import App
 from .models.configvars import ConfigVars
+from .models.dyno import Dyno
+from .models.invoice import Invoice
+from .models.key import Key
 from .models.logsession import LogSession
-from .models.oauth import OAuthClient, OAuthAuthorization, OAuthToken
+from .models.oauth import OAuthAuthorization, OAuthClient, OAuthToken
 from .rendezvous import Rendezvous
 from .structures import KeyedListResource, SSHKeyListResource
-from .models.account.feature import AccountFeature
-from requests.exceptions import HTTPError
-from pprint import pprint # noqa
-import requests
-import sys
 
 if sys.version_info > (3, 0):
     from urllib.parse import quote

--- a/heroku3/core.py
+++ b/heroku3/core.py
@@ -7,8 +7,9 @@ heroku3.core
 This module provides the base entrypoint for heroku3.py.
 """
 
-from .api import Heroku
 import requests
+
+from .api import Heroku
 
 
 def from_key(api_key, session=None, **kwargs):

--- a/heroku3/examples.py
+++ b/heroku3/examples.py
@@ -1,7 +1,9 @@
 # coding=utf-8
 import os
+from pprint import pprint  # noqa
+
 import heroku3
-from pprint import pprint# noqa
+
 #import socket
 
 #import httplib

--- a/heroku3/helpers.py
+++ b/heroku3/helpers.py
@@ -7,11 +7,10 @@ heroku3.helpers
 This module contians the helpers.
 """
 
+import sys
 from datetime import datetime
 
 from dateutil.parser import parse as parse_datetime
-
-import sys
 
 if sys.version_info > (3, 0):
     basestring = (str, bytes)

--- a/heroku3/models/app.py
+++ b/heroku3/models/app.py
@@ -1,7 +1,9 @@
-from ..models import BaseResource, User, Stack
+import sys
+from pprint import pprint  # NOQA
+
+from ..models import BaseResource, Stack, User
 from ..rendezvous import Rendezvous
 from ..structures import DynoListResource
-
 from .addon import Addon
 from .build import Build
 from .collaborator import Collaborator
@@ -13,9 +15,6 @@ from .logdrain import LogDrain
 from .logsession import LogSession
 from .region import Region
 from .release import Release
-
-from pprint import pprint # NOQA
-import sys
 
 if sys.version_info > (3, 0):
     from urllib.parse import quote

--- a/heroku3/models/build.py
+++ b/heroku3/models/build.py
@@ -1,6 +1,6 @@
-from . import BaseResource
-from . import User
+from . import BaseResource, User
 from .buildpack import Buildpack
+
 
 class Build(BaseResource):
     _dates = ['created_at','updated_at']
@@ -14,4 +14,3 @@ class Build(BaseResource):
  
     def __repr__(self):
         return "<build '{0} - {1}'>".format(self.id, self.status)
-

--- a/heroku3/models/buildpack.py
+++ b/heroku3/models/buildpack.py
@@ -1,5 +1,6 @@
 from . import BaseResource
 
+
 class Buildpack(BaseResource):
 
     _strs = [ 'url' ]
@@ -10,5 +11,3 @@ class Buildpack(BaseResource):
 
     def __repr__(self):
         return "<buildpack {}'>".format(self.url)
-
-

--- a/heroku3/models/collaborator.py
+++ b/heroku3/models/collaborator.py
@@ -1,4 +1,4 @@
-from .  import BaseResource, User
+from . import BaseResource, User
 
 
 class Collaborator(BaseResource):

--- a/heroku3/models/formation.py
+++ b/heroku3/models/formation.py
@@ -1,6 +1,6 @@
-from .  import BaseResource
 import sys
 
+from . import BaseResource
 
 if sys.version_info > (3, 0):
     from urllib.parse import quote

--- a/heroku3/models/invoice.py
+++ b/heroku3/models/invoice.py
@@ -13,5 +13,3 @@ class Invoice(BaseResource):
 
     def __repr__(self):
         return "<invoice '{}-{}'>".format(self.id,self.number)
-
-  

--- a/heroku3/models/key.py
+++ b/heroku3/models/key.py
@@ -1,4 +1,4 @@
-from .  import BaseResource
+from . import BaseResource
 
 
 class Key(BaseResource):

--- a/heroku3/models/logdrain.py
+++ b/heroku3/models/logdrain.py
@@ -1,4 +1,4 @@
-from .  import BaseResource
+from . import BaseResource
 from .addon import Addon
 
 

--- a/heroku3/models/logsession.py
+++ b/heroku3/models/logsession.py
@@ -1,5 +1,6 @@
-from .  import BaseResource
 import requests
+
+from . import BaseResource
 
 
 class LogSession(BaseResource):

--- a/heroku3/models/region.py
+++ b/heroku3/models/region.py
@@ -1,4 +1,4 @@
-from .  import BaseResource
+from . import BaseResource
 
 
 class Region(BaseResource):

--- a/heroku3/models/release.py
+++ b/heroku3/models/release.py
@@ -1,4 +1,4 @@
-from .  import BaseResource, User
+from . import BaseResource, User
 
 
 class Release(BaseResource):

--- a/heroku3/rendezvous.py
+++ b/heroku3/rendezvous.py
@@ -3,7 +3,7 @@ import select
 import ssl
 import os
 #from pprint import pprint
-from urllib.parse import urlparse, uses_netloc
+from six.moves.urllib.parse import urlparse, uses_netloc
 uses_netloc.append('rendezvous')
 
 

--- a/heroku3/rendezvous.py
+++ b/heroku3/rendezvous.py
@@ -1,9 +1,11 @@
-import socket
-import select
-import ssl
 import os
+import select
+import socket
+import ssl
+
 #from pprint import pprint
 from six.moves.urllib.parse import urlparse, uses_netloc
+
 uses_netloc.append('rendezvous')
 
 


### PR DESCRIPTION
urllib moved in python 3 so using six.moves allows this to
continue working in python2.7 and python3