### PR TITLE
fix: Use plain Python syntax to reraise exceptions.

### DIFF
--- a/heroku3/api.py
+++ b/heroku3/api.py
@@ -10,8 +10,6 @@ This module provides the basic API interface for Heroku.
 import sys
 from pprint import pprint  # noqa
 
-from future.utils import raise_
-
 import requests
 from requests.exceptions import HTTPError
 
@@ -296,16 +294,15 @@ class Heroku(HerokuCore):
             item = self._resource_deserialize(r.content.decode("utf-8"))
             app = App.new_from_dict(item, h=self)
         except HTTPError as e:
-            saved_exc = sys.exc_info()
             if "Name is already taken" in str(e):
                 try:
                     app = self.app(name)
                 except:
-                    raise_(saved_exc[0], saved_exc[1], saved_exc[2])
+                    raise
                 else:
                     print("Warning - {0:s}".format(e))
             else:
-                raise_(saved_exc[0], saved_exc[1], saved_exc[2])
+                raise
         return app
 
     def keys(self, **kwargs):

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,6 @@ required = [
     'requests>=1.2.3',
     'simplejson==3.3.1',
     'python-dateutil==2.6.0',
-    'future==0.16.0',
 ]
 
 


### PR DESCRIPTION
What seems to me a more future proof fix to issue #49 and #47. Also avoids pulling in what is a fairly huge dependency for fixing a small, yet important, I won't deny that, issue.

Again feeling a bit anxious about this given the lack of tests. If @simlun, who apparently uses this package Python 3.6, and others could validate before merging might be much safer.
