### PR TITLE
Fix potential KeyError when updating config

### DIFF
--- a/heroku3/models/configvars.py
+++ b/heroku3/models/configvars.py
@@ -104,5 +104,5 @@ class ConfigVars(object):
     @classmethod
     def new_from_dict(cls, d, h=None, **kwargs):
         # Override normal operation because of crazy api.
-        c = cls(d, kwargs.pop('app'), h=h, **kwargs)
+        c = cls(d, kwargs.pop('app', None), h=h, **kwargs)
         return c


### PR DESCRIPTION
fixes: #74

68d496e94a21063c950da015c1a0b0cb4824833e introduced a small
transposition from `get` to `pop`.