### PR TITLE
Install addon with attachment name

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -241,6 +241,7 @@ Install an Addon::
     addon = app.install_addon(plan_id_or_name='<id>', config={})
     addon = app.install_addon(plan_id_or_name='<name>', config={})
     addon = app.install_addon(plan_id_or_name=addonservice.id, config={})
+    addon = app.install_addon(plan_id_or_name=addonservice.id, config={}, attachment_name='ADDON_ATTACHMENT_CUSTOM_NAME')
 
 Remove an Addon::
 

--- a/heroku3/models/app.py
+++ b/heroku3/models/app.py
@@ -103,7 +103,7 @@ class App(BaseResource):
 
         return r.ok
 
-    def install_addon(self, plan_id_or_name, config=None):
+    def install_addon(self, plan_id_or_name, config=None, attachment_name=None):
 
         payload = {}
         if not config:
@@ -111,6 +111,9 @@ class App(BaseResource):
 
         payload['plan'] = plan_id_or_name
         payload['config'] = config
+
+        if attachment_name:
+            payload['attachment'] = {'name': attachment_name}
 
         r = self._h._http_resource(
             method='POST',


### PR DESCRIPTION
An attachment name is an optional parameter in [Heroku API](https://devcenter.heroku.com/articles/platform-api-reference#add-on-create) when creating an Addon. It is an auto-generated by default. For example, when installing a Heroku Postgres add-on it gets `HEROKU_POSTGRESQL_<COLOR>` name by default.

Setting a custom attachment name is required when your app utilizes several databases and you have to address them differently then attachment name allows addressing the correct database. Also, you can get the database credentials programmatically if you know the attachment name. The app config is populated by the database credentials in the `<ATTACHMENT_NAME>_URL` config key and this is the only way to create a database on Heroku and get its credentials programmatically.