### PR TITLE
fix rollback call

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -3,7 +3,7 @@ Heroku3.py
 
 .. image:: https://img.shields.io/pypi/v/heroku3.svg
    :target: https://pypi.org/project/heroku3
-   
+
 .. image:: https://circleci.com/gh/martyzz1/heroku3.py.svg?style=svg
    :target: https://circleci.com/gh/martyzz1/heroku3.py
 
@@ -12,7 +12,7 @@ Heroku3.py
 
 .. image:: https://www.travis-ci.org/martyzz1/heroku3.py.svg?branch=master
    :target: https://www.travis-ci.org/martyzz1/heroku3.py
-   
+
 .. image:: https://img.shields.io/pypi/pyversions/setuptools.svg
 
 This is the updated Python wrapper for the Heroku `API V3. <https://devcenter.heroku.com/articles/platform-api-reference>`_
@@ -569,15 +569,15 @@ List all releases::
     releaselist = app.releases()
     releaselist = app.releases(order_by='version')
 
-release information::
+Release information::
 
     for release in app.releases():
         print("{0}-{1} released by {2} on {3}".format(release.id, release.description, release.user.name, release.created_at))
 
-Rollbck to a release::
+Rollback to a release::
 
-    app.rollback("v{0}".format(release.version))
-    app.rollback("v108")
+    app.rollback(release.id)
+    app.rollback("489d7ce8-1cc3-4429-bb79-7907371d4c0e")
 
 Rename App
 ~~~~~~~~~~

--- a/heroku3/models/app.py
+++ b/heroku3/models/app.py
@@ -161,7 +161,7 @@ class App(BaseResource):
         r.raise_for_status()
         item = self._h._resource_deserialize(r.content.decode("utf-8"))
         return ConfigVars.new_from_dict(item, h=self._h, app=self)
-    
+
     def get_domain(self, hostname_or_id):
         """Get the domain for this app.."""
         r = self._h._http_resource(
@@ -169,7 +169,7 @@ class App(BaseResource):
             resource=('apps', self.name, 'domains', hostname_or_id),
         )
         r.raise_for_status()
-        
+
         item = self._h._resource_deserialize(resp.content.decode("utf-8"))
         return Domain.new_from_dict(item, h=self._h, app=self)
 
@@ -527,12 +527,11 @@ class App(BaseResource):
         )
 
     def rollback(self, release):
-        """Rolls back the release to the given version."""
+        """Rolls back the release to the given version uuid."""
         r = self._h._http_resource(
             method='POST',
             resource=('apps', self.name, 'releases'),
-            params={'rollback': release},
-            legacy=True
+            data=self._h._resource_serialize({'release': release})
         )
         r.raise_for_status()
         return self.releases()[-1]


### PR DESCRIPTION
The rollback API endpoint has changed, now it needs the release uuid sent as a POST param.
See context here: https://devcenter.heroku.com/articles/platform-api-reference#release-rollback