### PR TITLE
add a status attribute to the release model

### DIFF
--- a/heroku3/models/release.py
+++ b/heroku3/models/release.py
@@ -3,7 +3,7 @@ from .slug import Slug
 
 
 class Release(BaseResource):
-    _strs = ['description', 'id', 'user', 'commit', 'addons']
+    _strs = ['description', 'id', 'user', 'commit', 'addons', 'status']
     _ints = ['version']
     _dates = ['created_at', 'updated_at']
     _map = {'slug': Slug, 'user': User}


### PR DESCRIPTION
Doc: https://devcenter.heroku.com/articles/platform-api-reference#release-info
Add missing status attribute to the release model

<img width="772" alt="Screenshot 2020-01-07 19 35 56" src="https://user-images.githubusercontent.com/478052/71919422-eecbd000-3184-11ea-94f7-7b3a52aa058a.png">
