### PR TITLE
Added validation for app name

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,5 @@ venv
 
 .idea/
 *.iml
+Pipfile*
+.vscode

--- a/heroku3/api.py
+++ b/heroku3/api.py
@@ -17,7 +17,7 @@ from requests.exceptions import HTTPError
 
 # Project libraries
 from .models import Plan, RateLimit
-from .helpers import is_collection
+from .helpers import is_collection, validate_name
 from .models.app import App
 from .models.key import Key
 from .rendezvous import Rendezvous
@@ -31,6 +31,7 @@ from .models.app_setup import AppSetup
 from .models.configvars import ConfigVars
 from .models.logsession import LogSession
 from .models.account.feature import AccountFeature
+from .exceptions import InvalidNameException
 
 if sys.version_info > (3, 0):
     from urllib.parse import quote
@@ -354,7 +355,12 @@ class Heroku(HerokuCore):
             resource = ("apps",)
 
         if name:
-            payload["name"] = name
+            if validate_name(name):
+                payload["name"] = name
+            else:
+                raise InvalidNameException(
+                    "Name must start with a letter, end with a letter or digit and can only contain lowercase letters, digits, and dashes."
+                    )
 
         if stack_id_or_name:
             payload["stack"] = stack_id_or_name

--- a/heroku3/exceptions.py
+++ b/heroku3/exceptions.py
@@ -1,0 +1,2 @@
+class InvalidNameException(Exception):
+    pass

--- a/heroku3/helpers.py
+++ b/heroku3/helpers.py
@@ -97,7 +97,7 @@ def to_python(
 
     return obj
 
-def validate_name(name:str) -> bool:
+def validate_name(name):
     """
     name should conform to the pattern ^[a-z][a-z0-9-]{1,28}[a-z0-9]$ as
     specified in the Heroku API.

--- a/heroku3/helpers.py
+++ b/heroku3/helpers.py
@@ -8,6 +8,7 @@ This module contains the helpers.
 """
 
 import sys
+import re
 
 # Third party libraries
 from dateutil.parser import parse as parse_datetime
@@ -95,3 +96,13 @@ def to_python(
     # obj.__cache = in_dict
 
     return obj
+
+def validate_name(name:str) -> bool:
+    """
+    name should conform to the pattern ^[a-z][a-z0-9-]{1,28}[a-z0-9]$ as
+    specified in the Heroku API.
+    Returns True if name conforms to Heorku API naming standards,
+        False otherwise.
+    """
+    name_regex = re.compile(r"^[a-z][a-z0-9-]{1,28}[a-z0-9]$")
+    return True if name_regex.search(name) is not None else False

--- a/heroku3/models/app.py
+++ b/heroku3/models/app.py
@@ -20,6 +20,8 @@ from .logsession import LogSession
 from ..rendezvous import Rendezvous
 from ..structures import DynoListResource
 from .collaborator import Collaborator
+from ..exceptions import InvalidNameException
+from ..helpers import validate_name
 
 if sys.version_info > (3, 0):
     from urllib.parse import quote
@@ -399,7 +401,12 @@ class App(BaseResource):
 
         payload = {}
         if name:
-            payload["name"] = name
+            if validate_name(name):
+                payload["name"] = name
+            else:
+                raise InvalidNameException(
+                    "Name must start with a letter, end with a letter or digit and can only contain lowercase letters, digits, and dashes."
+                    )
         else:
             if maintenance or maintenance == 0:
                 payload["maintenance"] = maintenance


### PR DESCRIPTION
Added validation for the application name to conform to Heroku application naming standards according to the [docs](https://devcenter.heroku.com/articles/platform-api-reference#app). Helps prevent making request to the API if it doesn't conform to the standard as it will generate the same error.