### PR TITLE
app: add support for sni-endpoints

### DIFF
--- a/heroku3/models/app.py
+++ b/heroku3/models/app.py
@@ -11,6 +11,7 @@ from .build import Build
 from .buildpack_installation import BuildpackInstallation
 from .domain import Domain
 from .region import Region
+from .sni_endpoint import SNIEndpoint
 from ..models import User, Stack, BaseResource, Organization
 from .release import Release
 from .logdrain import LogDrain
@@ -154,6 +155,40 @@ class App(BaseResource):
         r.raise_for_status()
         item = self._h._resource_deserialize(r.content.decode("utf-8"))
         return ConfigVars.new_from_dict(item, h=self._h, app=self)
+
+    def sni_endpoints(self, **kwargs):
+        """The SNI (SSL) endpoints for this app."""
+        return self._h._get_resources(resource=("apps", self.id, "sni-endpoints"), obj=SNIEndpoint, app=self)
+
+    def add_sni_endpoint(self, certificate_chain, private_key):
+        r = self._h._http_resource(
+            method="POST",
+            resource=("apps", self.id, "sni-endpoints"),
+            data=self._h._resource_serialize({
+                "certificate_chain": certificate_chain,
+                "private_key": private_key,
+            })
+        )
+
+        r.raise_for_status()
+        item = self._h._resource_deserialize(r.content.decode("utf-8"))
+        return SNIEndpoint.new_from_dict(item, h=self._h, app=self)
+
+    def remove_sni_endpoint(self, sni_endpoint_id):
+        r = self._h._http_resource(
+            method="DELETE",
+            resource=("apps", self.id, "sni-endpoints", sni_endpoint_id)
+        )
+        r.raise_for_status()
+        return r.ok
+
+    def update_sni_endpoint(self, sni_endpoint_id):
+        r = self._h._http_resource(
+            method="PATCH",
+            resource=("apps", self.id, "sni-endpoints", sni_endpoint_id)
+        )
+        r.raise_for_status()
+        return r.ok
 
     def get_domain(self, hostname_or_id):
         """Get the domain for this app.."""

--- a/heroku3/models/sni_endpoint.py
+++ b/heroku3/models/sni_endpoint.py
@@ -1,0 +1,20 @@
+# Project libraries
+from . import BaseResource
+from .ssl_cert import SSLCert
+
+
+class SNIEndpoint(BaseResource):
+    """SSL Endpoint."""
+
+    _strs = ["certificate_chain", "cname", "display_name", "id", "name"]
+    _dates = ["created_at", "updated_at"]
+    _map = {"ssl_cert": SSLCert}
+    _pks = ["id"]
+    order_by = "id"
+
+    def __init__(self):
+        self.app = None
+        super(SNIEndpoint, self).__init__()
+
+    def __repr__(self):
+        return "<SSL Endpoint '{0}'>".format(self.name)

--- a/heroku3/models/ssl_cert.py
+++ b/heroku3/models/ssl_cert.py
@@ -1,0 +1,19 @@
+# Project libraries
+from . import BaseResource
+
+
+class SSLCert(BaseResource):
+    """SSL Certificate."""
+
+    _strs = ["issuer", "id", "subject"]
+    _dates = ["expires_at", "starts_at"]
+    _pks = ["id"]
+    _bools = ["ca_signed?", "self_signed?"]
+    order_by = "created_at"
+
+    def __init__(self):
+        self.app = None
+        super(SSLCert, self).__init__()
+
+    def __repr__(self):
+        return "<SSL Cert '{0}'>".format(self.id)


### PR DESCRIPTION
https://devcenter.heroku.com/articles/platform-api-reference#sni-endpoint

This commit adds support for the Heroku Platform API sni-endpoints
route. This route allows the user to list, create, delete, and patch SNI
endpoints.

SNI endpoints are the successor to the now-deprecated ssl-endpoints.