### PR TITLE
Added sni_endpoint to add_domain, cert_domains to SSLCert

### DIFF
--- a/heroku3/models/app.py
+++ b/heroku3/models/app.py
@@ -203,12 +203,15 @@ class App(BaseResource):
         """The domains for this app."""
         return self._h._get_resources(resource=("apps", self.name, "domains"), obj=Domain, app=self, **kwargs)
 
-    def add_domain(self, hostname):
+    def add_domain(self, hostname, sni_endpoint):
 
         r = self._h._http_resource(
             method="POST",
             resource=("apps", self.name, "domains"),
-            data=self._h._resource_serialize({"hostname": hostname}),
+            data=self._h._resource_serialize({
+                "hostname": hostname,
+                "sni_endpoint": sni_endpoint,
+            }),
         )
 
         r.raise_for_status()

--- a/heroku3/models/ssl_cert.py
+++ b/heroku3/models/ssl_cert.py
@@ -5,7 +5,7 @@ from . import BaseResource
 class SSLCert(BaseResource):
     """SSL Certificate."""
 
-    _strs = ["issuer", "id", "subject"]
+    _strs = ["cert_domains", "issuer", "id", "subject"]
     _dates = ["expires_at", "starts_at"]
     _pks = ["id"]
     _bools = ["ca_signed?", "self_signed?"]


### PR DESCRIPTION
The [Domain Create](https://devcenter.heroku.com/articles/platform-api-reference#domain-create) endpoint will start to require an `sni_endpoint` parameter on November 1, 2021:

https://devcenter.heroku.com/changelog-items/1938
>Beginning October 31, 2020, API requests to the Domain Create endpoint will accept an additional sni_endpoint parameter. This is a new attribute that can either be:
>
>   - A reference to a valid SNI endpoint or,
>   - null if the domain should not be associated with an SNI endpoint.
>
>Beginning November 1, 2021, this new parameter will be required.
>
>Consistent with our production API deprecation policy, API requests that do not include this parameter will continue to work for 12 months through October 31, 2021. On November 1, 2021, the API will respond with 422 errors if no sni_endpoint parameter is provided.
>
>Please update your API tooling as soon as practical to avoid these errors.

- Added `sni_endpoint` to `add_domain` method.
- Added `cert_domains` to `SSLCert` class for [SNI Endpoint](https://devcenter.heroku.com/articles/platform-api-reference#sni-endpoint).