### PR TITLE
Fix name of addon config key

### DIFF
--- a/heroku3/models/addon.py
+++ b/heroku3/models/addon.py
@@ -5,7 +5,7 @@ from . import Plan, BaseResource
 class Addon(BaseResource):
     """Heroku Addon."""
 
-    _strs = ["id", "config", "name", "provider_id", "web_url"]
+    _strs = ["id", "config_vars", "name", "provider_id", "web_url"]
     _pks = ["id", "name"]
     _map = {"plan": Plan}
     _dates = ["created_at", "updated_at"]


### PR DESCRIPTION
See https://devcenter.heroku.com/articles/platform-api-reference#add-on-info-by-app, which shows the key is `config_vars`, not `config`.


This can be bodged in using:

```python
Addon._strs.append("config_vars")
```

Which shows the correct value